### PR TITLE
feat: add CLI paddle table debug hooks (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ sudo apt install -y tesseract-ocr libgl1 libglib2.0-0 ccache
 ## Paddle engine caching
 
 When running with the default Paddle engine, the `PPStructure` model is initialized once per process and reused for every image to avoid repeated startup costs. Advanced users can reset the cached engine from Python by calling `image_to_csv.ocr.reset_paddle_engine()` before the next invocation if they need a fresh instance (for example, in tests).
+
+To inspect what Paddle believes it detected, run either command with `--debug-tables`. This will print a summary of the tables Paddle returned; add `--debug-tables-dir path/to/debug_html` to also save each raw HTML snippet for offline review.

--- a/src/image_to_csv/cli.py
+++ b/src/image_to_csv/cli.py
@@ -1,5 +1,6 @@
 import typer
 from pathlib import Path
+from typing import Optional
 import pandas as pd
 import cv2
 from .preprocess import preprocess
@@ -14,18 +15,59 @@ def _load_image(p: Path):
         raise typer.BadParameter(f"Cannot read image: {p}")
     return img
 
+def _build_paddle_debug_callback(image_label: str, save_dir: Optional[Path]):
+    """Create a debug callback that logs Paddle detections."""
+    save_dir = Path(save_dir) if save_dir else None
+
+    def _callback(result):
+        tables = []
+        for item in result or []:
+            if item.get("type") == "table":
+                tables.append(item)
+        typer.echo(f"[Paddle][{image_label}] detected {len(tables)} table(s)")
+        if not tables:
+            return
+        if save_dir:
+            save_dir.mkdir(parents=True, exist_ok=True)
+        for idx, tbl in enumerate(tables, 1):
+            html = (tbl.get("res") or {}).get("html", "")
+            preview = " ".join(html.split())
+            if len(preview) > 160:
+                preview = preview[:160] + "..."
+            typer.echo(f"  table {idx}: preview=\"{preview}\"")
+            if save_dir and html:
+                stem = Path(image_label).stem
+                target = save_dir / f"{stem}_table{idx}.html"
+                try:
+                    target.write_text(html, encoding="utf-8")
+                    typer.echo(f"    saved HTML -> {target}")
+                except Exception as exc:
+                    typer.echo(f"    failed to save HTML to {target}: {exc}")
+    return _callback
+
 @app.command()
 def file(
     path: Path = typer.Argument(..., help="Input image path"),
     out: Path = typer.Option(..., "--out", "-o", help="Output CSV file"),
     engine: str = typer.Option("paddle", "--engine", "-e", help="paddle or tesseract"),
     clean: bool = typer.Option(True, "--clean", help="Apply denoise/binarize/deskew"),
+    debug_tables: bool = typer.Option(False, "--debug-tables", help="Log Paddle table detections"),
+    debug_tables_dir: Optional[Path] = typer.Option(
+        None,
+        "--debug-tables-dir",
+        help="Directory to save Paddle table HTML when debugging (enables --debug-tables)",
+    ),
 ):
     """Process a single image file."""
     img = preprocess(_load_image(path), do_clean=clean)
     paddle_engine = get_paddle_engine() if engine == "paddle" else None
+    if debug_tables_dir:
+        debug_tables = True
     if paddle_engine:
-        html = ocr_table_paddle(img, engine=paddle_engine)
+        debug_cb = _build_paddle_debug_callback(path.name, debug_tables_dir) if debug_tables else None
+        html = ocr_table_paddle(img, engine=paddle_engine, debug_callback=debug_cb)
+        if debug_tables and not html:
+            typer.echo(f"[Paddle][{path.name}] no table HTML detected, falling back to tesseract")
         df = html_to_df(html) if html else lines_to_df(ocr_lines_tesseract(img))
     else:
         df = lines_to_df(ocr_lines_tesseract(img))
@@ -40,6 +82,12 @@ def folder(
     engine: str = typer.Option("paddle", "--engine", "-e", help="paddle or tesseract"),
     clean: bool = typer.Option(True, "--clean", "-c", help="Apply denoise/binarize/deskew"),
     glob: str = typer.Option("*.jpg", "--glob", "-g", help="Glob pattern for images"),
+    debug_tables: bool = typer.Option(False, "--debug-tables", help="Log Paddle table detections"),
+    debug_tables_dir: Optional[Path] = typer.Option(
+        None,
+        "--debug-tables-dir",
+        help="Directory to save Paddle table HTML when debugging (enables --debug-tables)",
+    ),
 ):
     """Batch convert all images in a folder."""
     paths = sorted(path.glob(glob))
@@ -47,11 +95,16 @@ def folder(
         raise typer.BadParameter(f"No files matched {glob} in {path}")
     frames = []
     paddle_engine = get_paddle_engine() if engine == "paddle" else None
+    if debug_tables_dir:
+        debug_tables = True
     for p in paths:
         typer.echo(f"Processing {p.name} ...")
         img = preprocess(_load_image(p), do_clean=clean)
         if paddle_engine:
-            html = ocr_table_paddle(img, engine=paddle_engine)
+            debug_cb = _build_paddle_debug_callback(p.name, debug_tables_dir) if debug_tables else None
+            html = ocr_table_paddle(img, engine=paddle_engine, debug_callback=debug_cb)
+            if debug_tables and not html:
+                typer.echo(f"[Paddle][{p.name}] no table HTML detected, falling back to tesseract")
             df = html_to_df(html) if html else lines_to_df(ocr_lines_tesseract(img))
         else:
             df = lines_to_df(ocr_lines_tesseract(img))

--- a/src/image_to_csv/ocr.py
+++ b/src/image_to_csv/ocr.py
@@ -1,6 +1,6 @@
 import inspect
 from importlib import import_module
-from typing import List
+from typing import Callable, List, Optional
 import numpy as np
 import cv2
 
@@ -61,7 +61,11 @@ def reset_paddle_engine():
     global _paddle_engine
     _paddle_engine = None
 
-def ocr_table_paddle(img_bgr, engine=None):
+def ocr_table_paddle(
+    img_bgr,
+    engine=None,
+    debug_callback: Optional[Callable[[Optional[list]], None]] = None,
+):
     """Run PaddleOCR table recognition and return extracted HTML if available.
 
     The Paddle engine is cached per process, so repeated calls avoid expensive
@@ -80,6 +84,11 @@ def ocr_table_paddle(img_bgr, engine=None):
             raise RuntimeError("Unsupported PaddleOCR engine type; no callable/predict interface")
     except Exception as e:
         raise RuntimeError(f"PaddleOCR inference failed: {e}") from e
+    if debug_callback:
+        try:
+            debug_callback(result)
+        except Exception:
+            pass
     for item in result or []:
         res = item.get("res", {})
         if item.get("type") == "table" and isinstance(res, dict) and "html" in res:

--- a/tests/test_ocr_cache.py
+++ b/tests/test_ocr_cache.py
@@ -30,3 +30,25 @@ def test_ocr_table_paddle_caches_engine(monkeypatch):
     assert second == first
     assert len(init_calls) == 1
     ocr.reset_paddle_engine()
+
+
+def test_ocr_table_paddle_debug_callback(monkeypatch):
+    """Debug callbacks receive the raw Paddle response."""
+    class FakeEngine:
+        def __call__(self, img):
+            return [{"type": "table", "res": {"html": "<table></table>"}}]
+
+    def fake_factory(*args, **kwargs):
+        return FakeEngine()
+
+    monkeypatch.setitem(sys.modules, "paddleocr", types.SimpleNamespace(PPStructure=fake_factory))
+    ocr.reset_paddle_engine()
+    img = np.zeros((2, 2, 3), dtype=np.uint8)
+    captured = []
+
+    def debug_cb(result):
+        captured.append(result)
+
+    ocr.ocr_table_paddle(img, debug_callback=debug_cb)
+    assert len(captured) == 1
+    assert captured[0][0]["res"]["html"] == "<table></table>"


### PR DESCRIPTION
## 🧾 Title
feat: add CLI paddle table debug hooks (#7)

## 🧠 Description
- Add `--debug-tables` and optional `--debug-tables-dir` flags to the `file` and `folder` commands so we can inspect PaddleOCR’s raw detections.
- When debugging is enabled, print the number of tables Paddle returned, emit a short HTML preview, and optionally write the full HTML to the specified directory.
- Extend `ocr_table_paddle` with a `debug_callback` hook and cover it via a regression test.

## 🧩 Changes Included
- [x] Added/updated documentation
- [x] Implemented new feature or enhancement
- [ ] Refactored existing code
- [ ] Improved error handling or logging
- [ ] Updated environment configuration
- [ ] Other (specify)

## 🎯 Purpose
Make Paddle’s output observable so we can understand why tables are/aren’t detected and capture raw HTML for follow-up parser work.

## 🔗 Related Issues / Epics
- **Issue:** #7 Log detected Paddle tables for inspection

## 🧪 Testing
1. `poetry run pytest -q`
2. Manual CLI: `poetry run image-to-csv folder input --out output.csv --debug-tables --debug-tables-dir debug_html`

## 🧰 Developer Notes
- Debug logging is opt-in; by default the CLI behaves as before.
- Saved HTML files are named `<image>_tableN.html` in the provided directory.
